### PR TITLE
modColumnVector remainder behaviour fix

### DIFF
--- a/src/Matrix.php
+++ b/src/Matrix.php
@@ -3290,7 +3290,7 @@ class Matrix implements Tensor
             $rowC = [];
 
             foreach ($rowA as $valueA) {
-                $rowC[] = $valueA % $valueB;
+                $rowC[] = ($valueA / $valueB - floor($valueA / $valueB)) * $valueB;
             }
 
             $c[] = $rowC;

--- a/tests/MatrixTest.php
+++ b/tests/MatrixTest.php
@@ -1348,9 +1348,9 @@ class MatrixTest extends TestCase
         $z = $this->a->mod($this->e);
 
         $expected = [
-            [0, -1, 0],
-            [0, 0, 0],
-            [0, -2, -1],
+            [ 2. ,  0.5,  2. ],
+            [-0. , -0. , -0. ],
+            [ 0.8,  3.6,  0.6]
         ];
 
         $this->assertInstanceOf(Matrix::class, $z);

--- a/tests/MatrixTest.php
+++ b/tests/MatrixTest.php
@@ -1348,9 +1348,9 @@ class MatrixTest extends TestCase
         $z = $this->a->mod($this->e);
 
         $expected = [
-            [ 2. ,  0.5,  2. ],
-            [-0. , -0. , -0. ],
-            [ 0.8,  3.6,  0.6]
+            [2.,  0.5,  2.],
+            [-0., -0., -0.],
+            [0.8,  3.6,  0.6]
         ];
 
         $this->assertInstanceOf(Matrix::class, $z);


### PR DESCRIPTION
modColumnVector does not return a correct result and PHPUnit is also expecting the wrong values. The true mod (checked using NumPy) for the implemented test (Tests/MatrixTest::modColumnVector) is:

```
[
     [ 2. ,  0.5,  2. ],
     [-0. , -0. , -0. ],
     [ 0.8,  3.6,  0.6]
 ]
```

PHP modulus operand "%" is made for integer only operations, witch can cause unexpected results when used for floating points.

**fmod** for some reason also failed to return the correct value and it is also famous for having problems with floating points, so it had to be implemented manually.