### PR TITLE
Make it so tests fail if PHP outputs warnings at startup

### DIFF
--- a/.github/workflows/ci-ext.sh
+++ b/.github/workflows/ci-ext.sh
@@ -24,3 +24,10 @@ pecl package /app/package.xml
 MAKE="make -j$(nproc)" pecl install tensor-*.tgz
 docker-php-ext-enable tensor
 php --ri tensor
+
+# Let's check that PHP doesn't output any warning
+TENSOR_PHP_OUTPUT="$(php -r ';' 2>&1)"
+if [ -n "$TENSOR_PHP_OUTPUT" ]; then
+  printf 'PHP displayed these warnings at startup:\n%s\n' "$TENSOR_PHP_OUTPUT" >&2
+  exit 1
+fi


### PR DESCRIPTION
When using the tensor PHP extension with PHP 8.1, at startup PHP displays the warnings reported at #28

For example. by simply running an empty PHP code, here's what we have:

```$  php -r ';'

Deprecated: Return type of Tensor\Vector::offsetGet($index) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Tensor\Vector::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of Tensor\Matrix::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0
```

What about making it so tests fails in this case?