### PR TITLE
Update prototypes in extension code

### DIFF
--- a/ext/tensor/matrix.zep.h
+++ b/ext/tensor/matrix.zep.h
@@ -731,7 +731,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_tensor_matrix_offsetget, 0, 1, I
 	ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_tensor_matrix_getiterator, 0, 0, Traversable, 0)
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_tensor_matrix_getiterator, 0, 0, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEPHIR_INIT_FUNCS(tensor_matrix_method_entry) {

--- a/ext/tensor/vector.zep.h
+++ b/ext/tensor/vector.zep.h
@@ -571,15 +571,22 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_tensor_vector_offsetexists, 0, 1
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_tensor_vector_offsetunset, 0, 1, IS_VOID, 0)
-
 	ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_tensor_vector_offsetget, 0, 1, IS_MIXED, 0)
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_tensor_vector_offsetget, 0, 0, 1)
+#endif
 	ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_tensor_vector_getiterator, 0, 0, Traversable, 0)
+#else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_tensor_vector_getiterator, 0, 0, 0)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEPHIR_INIT_FUNCS(tensor_vector_method_entry) {


### PR DESCRIPTION
Fixes a few deprecation warnings such as

  Return type of Tensor\Vector::getIterator() should either be compatible with
  IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be
  used to temporarily suppress the notice in Unknown on line 0