### PR TITLE
Change version metadata to 3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 3.0.5
+    - Upgraded Zephir dependency to 0.17
+
 - 3.0.4
     - Fixed bug in Vector less equal operation
 

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "extension-name": "tensor",
     "description": "A library and extension that provides objects for scientific computing in PHP.",
     "author": "The Rubix ML Community",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "verbose": true,
     "extra-cflags": "-O3",
     "extra-libs": "-lopenblas -llapacke -lgfortran",

--- a/ext/php_tensor.h
+++ b/ext/php_tensor.h
@@ -11,7 +11,7 @@
 #include "kernel/globals.h"
 
 #define PHP_TENSOR_NAME        "tensor"
-#define PHP_TENSOR_VERSION     "3.0.4"
+#define PHP_TENSOR_VERSION     "3.0.5"
 #define PHP_TENSOR_EXTNAME     "tensor"
 #define PHP_TENSOR_AUTHOR      "The Rubix ML Community"
 #define PHP_TENSOR_ZEPVERSION  "0.17.0-$Id$"


### PR DESCRIPTION
Just some housekeeping to go along with the 3.0.5 release

php should report the proper extension version when running
```console
php --ri tensor | grep Version
```