### PR TITLE
Add Mac install instructions  - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Install the Tensor extension via [PECL](https://pecl.php.net/package/Tensor):
 ```sh
 $ pecl install tensor
 ```
+Compiling on MacOS :
+To avoid some errors on Mac devices using homebrew, don't forget to add environment variables:
+```sh
+export LDFLAGS="-L$(brew --prefix openblas)/lib -L$(brew --prefix pcre2)/lib -L$(brew --prefix gcc)/lib/gcc/current"
+export CPPFLAGS="-I$(brew --prefix openblas)/include -I$(brew --prefix pcre2)/include -I$(brew --prefix gcc)/include"
+export PKG_CONFIG_PATH="$(brew --prefix openblas)/lib/pkgconfig:$(brew --prefix pcre2)/lib/pkgconfig:$(brew --prefix gcc)/lib/pkgconfig"
+export PATH="$(brew --prefix gcc)/bin:$PATH"
+export FC=$(brew --prefix gcc)/bin/gfortran
+```
 
 > **Note:** If both the library and extension are installed, the extension will take precedence.
 


### PR DESCRIPTION
Some environment variables to avoid errors like cblas.h unfound, pcre2.h unfound or gfortran unfound.